### PR TITLE
wip: AbstractSpreadsheetConnector updates

### DIFF
--- a/php-classes/Slate/Connectors/InfiniteCampus/Connector.php
+++ b/php-classes/Slate/Connectors/InfiniteCampus/Connector.php
@@ -28,6 +28,7 @@ class Connector extends \Slate\Connectors\AbstractSpreadsheetConnector implement
     // AbstractConnector overrides
     public static $title = 'Infinite Campus';
     public static $connectorId = 'infinite-campus';
+    public static $getSectionTerm;
 
     public static $studentsGraduationYearGroups = true;
 

--- a/php-classes/Slate/Connectors/InfiniteCampus/Connector.php
+++ b/php-classes/Slate/Connectors/InfiniteCampus/Connector.php
@@ -223,33 +223,6 @@ class Connector extends \Slate\Connectors\AbstractSpreadsheetConnector implement
         return $teachers;
     }
 
-    protected static function getSectionTerm(IJob $Job, Term $MasterTerm, Section $Section, array $row)
-    {
-        $year = substr($MasterTerm->StartDate, 0, 4);
-
-        switch ($row['TermQuarters']) {
-            case 4:
-                $termHandle = 'y' . $year;
-                break;
-            case 2:
-                $termHandle = 's' . $year . '-' . $row['TermLastQuarter']/2;
-                break;
-            case 1:
-                $termHandle = 'q' . $year . '-' . $row['TermLastQuarter'];
-                break;
-        }
-
-        if (!$Term = Term::getByHandle($termHandle)) {
-            throw new RemoteRecordInvalid(
-                'term-not-found',
-                'Term not found for handle: '.$termHandle,
-                $row,
-                $termHandle
-            );
-        }
-
-        return $Term;
-    }
 
     protected static function getSectionCourse(IJob $Job, Section $Section, array $row)
     {


### PR DESCRIPTION
This should be merged AFTER this [PR](https://github.com/SlateFoundation/slate/pull/204), and the deprecated method should be implemented as a variable override in all places this gets pulled down (SLA?)

- [x] chore: deprecate `getSectionTerm` override
